### PR TITLE
Fix the bug in tutorial (README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ local_info["server"] = "server_address"
 
 # `rm_dir = true` will clean up the site folder before generating it again. Default to false.
 # `opt_in = true` will add a link to this generator website in the side menu. Default to false.
-StaticWebPages.export_site(local_info; rm_dir = true, opt_in = true)
+StaticWebPages.export_site(;d=local_info rm_dir = true, opt_in = true)
 
 ## upload website (comment/delete if not needed)
 # unfortunately does not work yet on windows system, please sync manually for the moment

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ local_info["server"] = "server_address"
 
 # `rm_dir = true` will clean up the site folder before generating it again. Default to false.
 # `opt_in = true` will add a link to this generator website in the side menu. Default to false.
-StaticWebPages.export_site(;d=local_info rm_dir = true, opt_in = true)
+StaticWebPages.export_site(d=local_info, rm_dir = true, opt_in = true)
 
 ## upload website (comment/delete if not needed)
 # unfortunately does not work yet on windows system, please sync manually for the moment


### PR DESCRIPTION
Hello Jean!

It's a wonderful work! I've tried your package and re-run to generate the website.


## Method error of `export_cite` in tutorial 

I found there is a bug in README.md , it seems like a legacy code:

https://github.com/Azzaare/StaticWebPages.jl/blob/54b08c5349e2ba4fd49d5f21be0791c5528164a8/src/io.jl#L2

While in tutorial, the `run.jl` is created in :

```julia
StaticWebPages.export_site(local_info; rm_dir = true, opt_in = true)
```

It results in `method error`.

## Github action for automatic testing

I think it would be better to use [Github CI](https://docs.github.com/en/free-pro-team@latest/actions/guides/about-continuous-integration) for automatic code checking and updating.

How do you think?

Best,
Shao-Ting Chiu

---
Master Student
Graduate Institute of Bioengineering,
National Taiwan University.


